### PR TITLE
Refactor main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,8 @@ define(function (require, exports, module) {
     var CodeMirror = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
         LanguageManager = brackets.getModule("language/LanguageManager");
 
+    var tokenCComment, tokenSGMLComment, tokenString;
+
     CodeMirror.defineMode("stylus", function (config) {
         var indentUnit = config.indentUnit,
             type;


### PR DESCRIPTION
Quick summary:
- Load `CodeMirror` as a module, because `window.CodeMirror` is deprecated
- Fix JSLint warnings.

If you want, I could squash all JSLint related commits…
